### PR TITLE
Fixes for gradle dependency version check

### DIFF
--- a/gauge-java.go
+++ b/gauge-java.go
@@ -144,7 +144,7 @@ func getGaugeJavaDepFromMavenPom() (string, string, error) {
 	return matches[1], mavenPomFile, nil
 }
 
-func getGradleCommnad() string {
+func getGradleCommand() string {
 	windowsGradleW := filepath.Join(projectRoot, gradleCommadWindows)
 	unixGradleW := filepath.Join(projectRoot, gradleCommadUnix)
 	if runtime.GOOS == "windows" && fileExists(windowsGradleW) {
@@ -157,14 +157,14 @@ func getGradleCommnad() string {
 
 func getGaugeJavaDepFromGradleBuild() (string, string, error) {
 	args := []string{"-q", "dependencyInsight", "--dependency", "com.thoughtworks.gauge", "--configuration", "testCompileClasspath"}
-	cmd := exec.Command(getGradleCommnad(), args...)
+	cmd := exec.Command(getGradleCommand(), args...)
 	cmd.Stderr = os.Stderr
 	cmd.Dir = projectRoot
 	out, err := cmd.Output()
 	if err != nil {
 		return "", gradleBuildFile, err
 	}
-	re, err := regexp.Compile(`.*com\.thoughtworks\.gauge:gauge-java:(.*)`)
+	re, err := regexp.Compile(`.*com\.thoughtworks\.gauge:gauge-java:([^\s]+)`)
 	if err != nil {
 		return "", gradleBuildFile, fmt.Errorf("failed to compile regex. %w", err)
 	}


### PR DESCRIPTION
The following command may return the gauge version with space and text after a gauge version

```sh
./gradlew -q tests:dependencyInsight --dependency com.thoughtworks.gauge --configuration testCompileClasspath
```

E.g.

```sh
➜  project git:(master) ./gradlew -q tests:dependencyInsight --dependency com.thoughtworks.gauge --configuration testCompileClasspath
com.thoughtworks.gauge:gauge-java:0.9.2 (by constraint)
  Variant compile:
    | Attribute Name                 | Provided | Requested    |
    |--------------------------------|----------|--------------|
    | org.gradle.status              | release  |              |
    | org.gradle.category            | library  | library      |
    | org.gradle.libraryelements     | jar      | classes      |
    | org.gradle.usage               | java-api | java-api     |
    | org.gradle.dependency.bundling |          | external     |
    | org.gradle.jvm.environment     |          | standard-jvm |
    | org.gradle.jvm.version         |          | 17           |
```

The change is to match a version until there's a space.